### PR TITLE
Add ball-line collisions

### DIFF
--- a/jeznes.c
+++ b/jeznes.c
@@ -80,8 +80,10 @@ void main(void) {
         }
 
 #if DEBUG
+#if DRAW_GRAY_LINE
         // For debugging, render a line indicating how much CPU is used.
         gray_line();
+#endif
 #endif
     }
 }
@@ -112,7 +114,7 @@ void init_game(void) {
         update_nearest_tile(temp_byte_1);
 
         set_player_orientation_flag(temp_byte_1, ORIENTATION_HORIZ);
-        unset_player_is_place_pressed(temp_byte_1);
+        unset_player_is_place_pressed_flag(temp_byte_1);
         unset_player_is_rotate_pressed(temp_byte_1);
         unset_line_is_started_flag(temp_byte_1);
     }
@@ -283,57 +285,6 @@ void draw_balls(void) {
     }
 }
 
-void check_ball_line_collisions(void) {
-    for (temp_byte_1 = 0; temp_byte_1 < get_ball_count(); ++temp_byte_1) {
-        temp_int_1 = balls[temp_byte_1].nearest_playfield_tile;
-        temp_byte_2 = playfield[temp_int_1];
-
-        if (get_playfield_tile_type_from_byte(temp_byte_2) == PLAYFIELD_LINE) {
-            temp_byte_3 = get_playfield_line_index_flag_from_byte(temp_byte_2);
-
-            if (get_playfield_line_orientation_flag_from_byte(temp_byte_2) == ORIENTATION_VERT) {
-                temp_signed_byte_1 = -32;
-            } else {
-                temp_signed_byte_1 = -1;
-            }
-
-            if (get_playfield_line_direction_flag_from_byte(temp_byte_2) == LINE_DIRECTION_POSITIVE) {
-                set_line_is_positive_complete_flag(temp_byte_3);
-                temp_int_1 = lines[temp_byte_3].current_pos;
-
-                // If the other direction is also complete, reset the is_started flag of the line.
-                if (get_line_is_negative_complete_flag(temp_byte_3)) {
-                    unset_line_is_started_flag(temp_byte_3);
-                }
-            } else {
-                set_line_is_negative_complete_flag(temp_byte_3);
-                temp_int_1 = lines[temp_byte_3].current_neg;
-                temp_signed_byte_1 *= -1;
-
-                // If the other direction is also complete, reset the is_started flag of the line.
-                if (get_line_is_positive_complete_flag(temp_byte_3)) {
-                    unset_line_is_started_flag(temp_byte_3);
-                }
-            }
-
-            // Walk back across the line segment (to origin) and reset the playfield tiles to uncleared.
-            while (1) {
-                set_playfield_tile(temp_int_1, PLAYFIELD_UNCLEARED, TILE_INDEX_PLAYFIELD_UNCLEARED);
-                if (temp_int_1 == lines[temp_byte_3].origin) {
-                    break;
-                }
-                temp_int_1 += temp_signed_byte_1;
-            }
-
-            lives_count--;
-            // TODO: If lives_count == 0, set game state to game over?
-
-            // We changed the lives count, let's redraw the HUD.
-            game_state = GAME_STATE_REQUEST_HUD_UPDATE;
-        }
-    }
-}
-
 #define get_player_sprite_frame() (get_frame_count() >> 3 & 1)
 
 void draw_player(unsigned char player_index) {
@@ -350,169 +301,299 @@ void draw_tile_highlight(unsigned char player_index) {
     }
 }
 
-void draw_line(unsigned char line_index) {
-    if (get_line_is_started_flag(line_index)) {
-        if (get_line_orientation_flag(line_index) == ORIENTATION_VERT) {
-            temp_byte_3 = SPRITE_INDEX_PLAYFIELD_LINE_VERT_BASE + lines[line_index].current_block_completion;
-            temp_byte_4 = OAM_FLIP_V;
-        } else {
-            temp_byte_3 = SPRITE_INDEX_PLAYFIELD_LINE_HORIZ_BASE + lines[line_index].current_block_completion;
-            temp_byte_4 = OAM_FLIP_H;
-        }
-
-        if (!get_line_is_negative_complete_flag(line_index)) {
-            temp_int_1 = lines[line_index].current_neg;
-            oam_spr(playfield_index_pixel_coord_x(temp_int_1), playfield_index_pixel_coord_y(temp_int_1) - 1, temp_byte_3, 1 | temp_byte_4);
-        }
-
-        if (!get_line_is_positive_complete_flag(line_index)) {
-            temp_int_1 = lines[line_index].current_pos;
-            oam_spr(playfield_index_pixel_coord_x(temp_int_1), playfield_index_pixel_coord_y(temp_int_1) - 1, temp_byte_3, 1);
-        }
-    }
-}
-
 #define get_line_orientation() (temp_byte_4)
 #define set_line_orientation(a) (temp_byte_4 = (a))
-#define get_delta_y() (temp_byte_5)
-#define set_delta_y(a) (temp_byte_5 = (a))
 #define get_current_playfield_index() (temp_int_1)
 #define set_current_playfield_index(a) (temp_int_1 = (a))
-#define get_was_line_completed() (temp_byte_3)
-#define set_was_line_completed(a) (temp_byte_3 = (a))
+#define get_was_line_segment_completed() (temp_byte_3)
+#define set_was_line_segment_completed(a) (temp_byte_3 = (a))
+
+#define get_tile_index_delta() (temp_byte_5)
+#define set_tile_index_delta(a) (temp_byte_5 = (a))
+#define get_negative_line_segment_origin() (temp_int_2)
+#define set_negative_line_segment_origin(a) (temp_int_2 = (a))
+#define get_positive_line_segment_origin() (temp_int_2)
+#define set_positive_line_segment_origin(a) (temp_int_2 = (a))
+
+// The tile index delta is the number we add to a playfield tile index to move
+// to the next playfield tile along the line segment.
+// |orientation| is the line orientation and must be one of ORIENTATION_HORIZ
+// or ORIENTATION_VERT.
+#define compute_tile_index_delta(orientation) ((orientation) * 31 + 1)
 
 void update_line(unsigned char line_index) {
-    if (get_line_is_started_flag(line_index)) {
-        set_was_line_completed(FALSE);
+    // Do nothing if the line is not started.
+    if (!get_line_is_started_flag(line_index)) {
+        return;
+    }
 
-        // The playfield tile at the front of each line segment is the only one
-        // we need to worry about here.
-        // The tile is 8 pixels wide and we draw one line of pixels at a time.
-        // When we've reached completion of the tile, move the front of both
-        // line segments forward in their directions.
-        if (lines[line_index].current_block_completion == 8) {
-            set_line_orientation(get_line_orientation_flag(line_index));
-            if (get_line_orientation() == ORIENTATION_VERT) {
-                set_delta_y(32);
-            } else {
-                set_delta_y(1);
-            }
+    set_was_line_segment_completed(FALSE);
 
-            if (!get_line_is_negative_complete_flag(line_index)) {
-                // Before moving the current line head, update the metadata for the tile we're moving from
-                set_current_playfield_index(lines[line_index].current_neg);
-                set_playfield_tile(get_current_playfield_index(), get_playfield_tile_type_line(get_line_orientation(), line_index, LINE_DIRECTION_NEGATIVE), get_playfield_bg_tile_line(get_line_orientation()));
+    // The playfield tile at the front of each line segment is the only one
+    // we need to worry about here.
+    // The tile is 8 pixels wide and we draw one line of pixels at a time.
+    // When we've reached completion of the tile, move the front of both
+    // line segments forward in their directions.
+    if (lines[line_index].current_block_completion == 8) {
+        set_line_orientation(get_line_orientation_flag(line_index));
+        set_tile_index_delta(compute_tile_index_delta(get_line_orientation()));
+        set_negative_line_segment_origin(lines[line_index].origin);
 
-                set_current_playfield_index(get_current_playfield_index() - get_delta_y());
-                lines[line_index].current_neg = get_current_playfield_index();
+        // Try and move the front of the negative-direction line segment forward
+        // and complete the line segment if it's reached a wall.
+        if (!get_line_is_negative_complete_flag(line_index)) {
+            // Before moving the line segment forward, update the metadata for the tile we're moving from.
+            set_current_playfield_index(get_negative_line_segment_origin() - lines[line_index].tile_step_count * get_tile_index_delta());
 
-                // If the current block is not an uncleared tile, that means we hit the end for that line.
-                // Walk back over the blocks until we reach origin and update them to cleared.
-                if (playfield[get_current_playfield_index()] != PLAYFIELD_UNCLEARED) {
-                    while (1) {
-                        set_current_playfield_index(get_current_playfield_index() + get_delta_y());
-                        if (get_current_playfield_index() == lines[line_index].origin) {
-                            break;
-                        }
-                        cleared_tile_count++;
-                        set_playfield_tile(get_current_playfield_index(), PLAYFIELD_WALL, TILE_INDEX_PLAYFIELD_CLEARED);
+            // While it was the front of the line segment, current playfield tile was being
+            // drawn as a sprite. Now that it's complete, update the playfield and bg tile.
+            set_playfield_tile(get_current_playfield_index(), get_playfield_tile_type_line(get_line_orientation(), line_index, LINE_DIRECTION_NEGATIVE), get_playfield_bg_tile_line(get_line_orientation()));
+
+            // Now move the front of the line segment forward by one tile.
+            set_current_playfield_index(get_current_playfield_index() - get_tile_index_delta());
+
+            // If the next tile is not an uncleared tile, that means we hit the end for the line segment.
+            // Walk back over the tiles until we reach line segment origin and update them to cleared.
+            if (get_playfield_tile_type(get_current_playfield_index()) == PLAYFIELD_WALL) {
+                while (1) {
+                    // Walk back towards origin by one tile.
+                    set_current_playfield_index(get_current_playfield_index() + get_tile_index_delta());
+                    // Update the tile to cleared.
+                    cleared_tile_count++;
+                    set_playfield_tile(get_current_playfield_index(), PLAYFIELD_WALL, TILE_INDEX_PLAYFIELD_CLEARED);
+                    // Stop when we reach the origin.
+                    if (get_current_playfield_index() == get_negative_line_segment_origin()) {
+                        break;
                     }
-                    set_line_is_negative_complete_flag(line_index);
-
-                    // When both directions are complete the line is done
-                    if (get_line_is_positive_complete_flag(line_index)) {
-                        cleared_tile_count++;
-                        set_playfield_tile(lines[line_index].origin, PLAYFIELD_WALL, TILE_INDEX_PLAYFIELD_CLEARED);
-
-                        unset_line_is_started_flag(line_index);
-                    }
-
-                    set_was_line_completed(TRUE);
                 }
-            }
 
-            // Now do the positive direction.
-            if (!get_line_is_positive_complete_flag(line_index)) {
-                // Before moving the current line head, update the metadata for the tile we're moving from
-                set_current_playfield_index(lines[line_index].current_pos);
-                set_playfield_tile(get_current_playfield_index(), get_playfield_tile_type_line(get_line_orientation(), line_index, LINE_DIRECTION_POSITIVE), get_playfield_bg_tile_line(get_line_orientation()));
+                // Finished the negative-direction line segment.
+                set_line_is_negative_complete_flag(line_index);
 
-                set_current_playfield_index(get_current_playfield_index() + get_delta_y());
-                lines[line_index].current_pos = get_current_playfield_index();
-
-                if (playfield[get_current_playfield_index()] != PLAYFIELD_UNCLEARED) {
-                    while (1) {
-                        set_current_playfield_index(get_current_playfield_index() - get_delta_y());
-                        if (get_current_playfield_index() == lines[line_index].origin) {
-                            break;
-                        }
-                        cleared_tile_count++;
-                        set_playfield_tile(get_current_playfield_index(), PLAYFIELD_WALL, TILE_INDEX_PLAYFIELD_CLEARED);
-                    }
-                    set_line_is_positive_complete_flag(line_index);
-
-                    // When both directions are complete the line is done
-                    if (get_line_is_negative_complete_flag(line_index)) {
-                        cleared_tile_count++;
-                        set_playfield_tile(lines[line_index].origin, PLAYFIELD_WALL, TILE_INDEX_PLAYFIELD_CLEARED);
-
-                        unset_line_is_started_flag(line_index);
-                    }
-
-                    set_was_line_completed(TRUE);
+                // When line segments in both directions are complete, the line is done.
+                if (get_line_is_positive_complete_flag(line_index)) {
+                    unset_line_is_started_flag(line_index);
                 }
-            }
 
-            lines[line_index].current_block_completion = 0;
-        } else {
-            if (get_frame_count() % 3 == 0) {
-                ++lines[line_index].current_block_completion;
+                set_was_line_segment_completed(TRUE);
             }
         }
 
-        if (get_was_line_completed()) {
-            line_completed();
+        // Now do the positive direction.
+        if (!get_line_is_positive_complete_flag(line_index)) {
+            // Calculate positive-direction line segment origin based
+            // on negative-direction line segment origin.
+            set_positive_line_segment_origin(get_negative_line_segment_origin() + get_tile_index_delta());
+
+            // Before moving the line segment forward, update the metadata for the tile we're moving from.
+            set_current_playfield_index(get_positive_line_segment_origin() + lines[line_index].tile_step_count * get_tile_index_delta());
+
+            // While it was the front of the line segment, current playfield tile was being
+            // drawn as a sprite. Now that it's complete, update the playfield and bg tile.
+            set_playfield_tile(get_current_playfield_index(), get_playfield_tile_type_line(get_line_orientation(), line_index, LINE_DIRECTION_POSITIVE), get_playfield_bg_tile_line(get_line_orientation()));
+
+            // Now move the front of the line segment forward by one tile.
+            set_current_playfield_index(get_current_playfield_index() + get_tile_index_delta());
+
+            // If the next tile is not an uncleared tile, that means we hit the end for the line segment.
+            // Walk back over the tiles until we reach line segment origin and update them to cleared.
+            if (get_playfield_tile_type(get_current_playfield_index()) == PLAYFIELD_WALL) {
+                while (1) {
+                    // Walk back towards origin by one tile.
+                    set_current_playfield_index(get_current_playfield_index() - get_tile_index_delta());
+                    // Update the tile to cleared.
+                    cleared_tile_count++;
+                    set_playfield_tile(get_current_playfield_index(), PLAYFIELD_WALL, TILE_INDEX_PLAYFIELD_CLEARED);
+                    // Stop when we reach the origin.
+                    if (get_current_playfield_index() == get_positive_line_segment_origin()) {
+                        break;
+                    }
+                }
+
+                // Finished the positive-direction line segment.
+                set_line_is_positive_complete_flag(line_index);
+
+                // When line segments in both directions are complete, the line is done.
+                if (get_line_is_negative_complete_flag(line_index)) {
+                    unset_line_is_started_flag(line_index);
+                }
+
+                set_was_line_segment_completed(TRUE);
+            }
         }
+
+        lines[line_index].current_block_completion = 0;
+        lines[line_index].tile_step_count++;
+    } else {
+        if (get_frame_count() % 3 == 0) {
+            ++lines[line_index].current_block_completion;
+        }
+    }
+
+    if (get_was_line_segment_completed()) {
+        line_completed();
     }
 }
 
 void start_line(unsigned char player_index) {
     if (pads[player_index] & PAD_A) {
-        if (!get_player_is_place_pressed(player_index)) {
-            set_player_is_place_pressed(player_index);
-
-            // Do nothing if a line is already active
-            if (get_line_is_started_flag(player_index)) {
-                return;
-            }
-
-            temp_int_1 = players[player_index].nearest_playfield_tile;
-            // We only want to start a line if the origin tile is not already cleared
-            if (playfield[temp_int_1] != PLAYFIELD_UNCLEARED) {
-                return;
-            }
-
-            // Update the playfield in-memory structure
-            set_line_orientation(get_player_orientation_flag(player_index));
-            playfield[temp_int_1] = get_playfield_tile_type_line(get_line_orientation(), player_index, LINE_DIRECTION_POSITIVE);
-
-            // Set the bg tile
-            one_vram_buffer(get_playfield_bg_tile_line(get_line_orientation()), get_ppu_addr(0, players[player_index].nearest_tile_x, players[player_index].nearest_tile_y));
-
-            // Update the line data
-            lines[player_index].current_block_completion = 8;
-            lines[player_index].origin = temp_int_1;
-            lines[player_index].current_neg = temp_int_1;
-            lines[player_index].current_pos = temp_int_1;
-            lines[player_index].tile_step_count = 0;
-
-            set_line_is_started_flag(player_index);
-            unset_line_is_negative_complete_flag(player_index);
-            unset_line_is_positive_complete_flag(player_index);
-            set_line_orientation_flag(player_index, get_line_orientation());
+        // Do nothing if the player is holding the button and we already handled the press.
+        if (get_player_is_place_pressed_flag(player_index)) {
+            return;
         }
+
+        // Keep track that user is pressing this button.
+        set_player_is_place_pressed_flag(player_index);
+
+        // Do nothing if a line is already started for |player_index|.
+        if (get_line_is_started_flag(player_index)) {
+            return;
+        }
+
+        // Origin for the line is whatever tile we're tracking as "nearest" to the player metasprite.
+        // This is technically the origin tile for the negative-direction line segment.
+        // The origin tile for the positive-direction line segment is origin + 1 (for horiz line) or
+        // origin + 32 (for vert line) but we only keep track of one origin in the line itself.
+        set_negative_line_segment_origin(players[player_index].nearest_playfield_tile);
+
+        // We only want to start a line if the origin tile is not already cleared.
+        if (get_playfield_tile_type(get_negative_line_segment_origin()) == PLAYFIELD_WALL) {
+            return;
+        }
+
+        // Orientation of the line itself matches the current orientation of the player.
+        set_line_orientation(get_player_orientation_flag(player_index));
+
+        // Update the playfield origin tile.
+        set_playfield_tile(get_negative_line_segment_origin(), get_playfield_tile_type_line(get_line_orientation(), player_index, LINE_DIRECTION_NEGATIVE), get_playfield_bg_tile_line(get_line_orientation()));
+
+        // Update the line data for the negative-direction line segment.
+        lines[player_index].origin = get_negative_line_segment_origin();
+        unset_line_is_negative_complete_flag(player_index);
+
+        // Now check to see if we can start a positive-direction line segment.
+        set_tile_index_delta(compute_tile_index_delta(get_line_orientation()));
+        set_positive_line_segment_origin(get_negative_line_segment_origin() + get_tile_index_delta());
+
+        // We can only start the positive-direction line segment if it would have origin on an
+        // uncleared playfield tile.
+        if (get_playfield_tile_type(get_positive_line_segment_origin()) != PLAYFIELD_WALL) {
+            // Update the positive-direction line segment origin playfield tile.
+            set_playfield_tile(get_positive_line_segment_origin(), get_playfield_tile_type_line(get_line_orientation(), player_index, LINE_DIRECTION_POSITIVE), get_playfield_bg_tile_line(get_line_orientation()));
+            unset_line_is_positive_complete_flag(player_index);
+        }
+
+        // Current line segment front tile is the origin tile.
+        lines[player_index].tile_step_count = 0;
+        // The origin tiles start at complete.
+        lines[player_index].current_block_completion = 8;
+
+        set_line_orientation_flag(player_index, get_line_orientation());
+        set_line_is_started_flag(player_index);
     } else {
-        unset_player_is_place_pressed(player_index);
+        unset_player_is_place_pressed_flag(player_index);
+    }
+}
+
+void draw_line(unsigned char line_index) {
+    if (get_line_is_started_flag(line_index)) {
+        set_line_orientation(get_line_orientation_flag(line_index));
+        set_tile_index_delta(compute_tile_index_delta(get_line_orientation()));
+        set_negative_line_segment_origin(lines[line_index].origin);
+
+        if (!get_line_is_negative_complete_flag(line_index)) {
+            set_current_playfield_index(get_negative_line_segment_origin() - lines[line_index].tile_step_count * get_tile_index_delta());
+
+            // Negative-direction line segment front tile sprite needs to be flipped (OAM_FLIP_H 0x40).
+            // If the line is vertical, we need to do vertical flip instead (OAM_FLIP_V 0x80).
+            temp_byte_2 = OAM_FLIP_H + OAM_FLIP_H * get_line_orientation();
+            oam_spr(playfield_index_pixel_coord_x(get_current_playfield_index()), playfield_index_pixel_coord_y(get_current_playfield_index()) - 1, get_line_sprite_index(get_line_orientation(), lines[line_index].current_block_completion), 1 | temp_byte_2);
+        }
+
+        if (!get_line_is_positive_complete_flag(line_index)) {
+            set_positive_line_segment_origin(get_negative_line_segment_origin() + get_tile_index_delta());
+            set_current_playfield_index(get_positive_line_segment_origin() + lines[line_index].tile_step_count * get_tile_index_delta());
+            oam_spr(playfield_index_pixel_coord_x(get_current_playfield_index()), playfield_index_pixel_coord_y(get_current_playfield_index()) - 1, get_line_sprite_index(get_line_orientation(), lines[line_index].current_block_completion), 1);
+        }
+    }
+}
+
+void check_ball_line_collisions(void) {
+    for (temp_byte_1 = 0; temp_byte_1 < get_ball_count(); ++temp_byte_1) {
+        set_current_playfield_index(balls[temp_byte_1].nearest_playfield_tile);
+        temp_byte_2 = playfield[get_current_playfield_index()];
+
+        if (get_playfield_tile_type_from_byte(temp_byte_2) != PLAYFIELD_LINE) {
+            // No collision.
+            continue;
+        }
+
+        set_line_orientation(get_playfield_line_orientation_flag_from_byte(temp_byte_2));
+        set_tile_index_delta(compute_tile_index_delta(get_line_orientation()));
+        temp_byte_3 = get_playfield_line_index_flag_from_byte(temp_byte_2);
+        set_negative_line_segment_origin(lines[temp_byte_3].origin);
+
+        if (get_playfield_line_direction_flag_from_byte(temp_byte_2) == LINE_DIRECTION_NEGATIVE) {
+            // Playfield tile index of the line segment front tile.
+            // This is drawn as a sprite and we haven't updated the playfield
+            // metadata to include the line flags for this tile so we don't need
+            // to do anything to the playfield for this tile index.
+            set_current_playfield_index(get_negative_line_segment_origin() - lines[temp_byte_3].tile_step_count * get_tile_index_delta());
+
+            // Walk back across the line segment (to origin) and reset the playfield tiles to uncleared.
+            while (1) {
+                // Walk back towards origin by one tile.
+                set_current_playfield_index(get_current_playfield_index() + get_tile_index_delta());
+                // Reset the tile to uncleared.
+                set_playfield_tile(get_current_playfield_index(), PLAYFIELD_UNCLEARED, TILE_INDEX_PLAYFIELD_UNCLEARED);
+                // Stop when we reach the origin.
+                if (get_current_playfield_index() == get_negative_line_segment_origin()) {
+                    break;
+                }
+            }
+
+            // Turn off the negative-direction line segment - the collision stopped it.
+            set_line_is_negative_complete_flag(temp_byte_3);
+
+            // If the other direction is also complete, reset the is_started flag of the line.
+            if (get_line_is_positive_complete_flag(temp_byte_3)) {
+                unset_line_is_started_flag(temp_byte_3);
+            }
+        } else {
+            set_positive_line_segment_origin(get_negative_line_segment_origin() + get_tile_index_delta());
+
+            // Playfield tile index of the line segment front tile.
+            // This is drawn as a sprite and we haven't updated the playfield
+            // metadata to include the line flags for this tile so we don't need
+            // to do anything to the playfield for this tile index.
+            set_current_playfield_index(get_positive_line_segment_origin() + lines[temp_byte_3].tile_step_count * get_tile_index_delta());
+
+            // Walk back across the line segment (to origin) and reset the playfield tiles to uncleared.
+            while (1) {
+                // Walk back towards origin by one tile.
+                set_current_playfield_index(get_current_playfield_index() - get_tile_index_delta());
+                // Reset the tile to uncleared.
+                set_playfield_tile(get_current_playfield_index(), PLAYFIELD_UNCLEARED, TILE_INDEX_PLAYFIELD_UNCLEARED);
+                // Stop when we reach the origin.
+                if (get_current_playfield_index() == get_positive_line_segment_origin()) {
+                    break;
+                }
+            }
+
+            // Turn off the positive-direction line segment - the collision stopped it.
+            set_line_is_positive_complete_flag(temp_byte_3);
+
+            // If the other direction is also complete, reset the is_started flag of the line.
+            if (get_line_is_negative_complete_flag(temp_byte_3)) {
+                unset_line_is_started_flag(temp_byte_3);
+            }
+        }
+
+        lives_count--;
+        // TODO: If lives_count == 0, set game state to game over?
+
+        // We changed the lives count, let's redraw the HUD.
+        game_state = GAME_STATE_REQUEST_HUD_UPDATE;
     }
 }
 

--- a/jeznes.c
+++ b/jeznes.c
@@ -385,8 +385,11 @@ void update_line(unsigned char line_index) {
     if (get_line_is_started_flag(line_index)) {
         set_was_line_completed(FALSE);
 
-        // There are 8 pixels in the block and we draw them one by one.
-        // When we've reached completion of the 8 pixels, move the current head of the lines forward in either direction.
+        // The playfield tile at the front of each line segment is the only one
+        // we need to worry about here.
+        // The tile is 8 pixels wide and we draw one line of pixels at a time.
+        // When we've reached completion of the tile, move the front of both
+        // line segments forward in their directions.
         if (lines[line_index].current_block_completion == 8) {
             set_line_orientation(get_line_orientation_flag(line_index));
             if (get_line_orientation() == ORIENTATION_VERT) {
@@ -501,6 +504,7 @@ void start_line(unsigned char player_index) {
             lines[player_index].origin = temp_int_1;
             lines[player_index].current_neg = temp_int_1;
             lines[player_index].current_pos = temp_int_1;
+            lines[player_index].tile_step_count = 0;
 
             set_line_is_started_flag(player_index);
             unset_line_is_negative_complete_flag(player_index);

--- a/jeznes.c
+++ b/jeznes.c
@@ -230,6 +230,7 @@ void move_ball(unsigned char ball_index) {
         temp_int_1 = temp_byte_4 + 32 * temp_byte_5 - PLAYFIELD_FIRST_TILE_INDEX;
         temp_byte_4 = (temp_byte_4 << 3) + 8;
     }
+    // Bounce off a wall tile
     if (playfield[temp_int_1] == PLAYFIELD_WALL) {
         balls[ball_index].x_velocity *= -1;
         temp_byte_2 = temp_byte_4;
@@ -253,6 +254,7 @@ void move_ball(unsigned char ball_index) {
         temp_int_1 = temp_byte_5 + 32 * temp_byte_4 - PLAYFIELD_FIRST_TILE_INDEX;
         temp_byte_4 = (temp_byte_4 << 3) + 8;
     }
+    // Bounce off a wall tile
     if (playfield[temp_int_1] == PLAYFIELD_WALL) {
         balls[ball_index].y_velocity *= -1;
         temp_byte_3 = temp_byte_4;
@@ -275,6 +277,12 @@ void draw_balls(void) {
         temp_int_1 = balls[temp_byte_1].nearest_playfield_tile;
         oam_spr(playfield_index_pixel_coord_x(temp_int_1), playfield_index_pixel_coord_y(temp_int_1) - 1, TILE_INDEX_TILE_HIGHLIGHT, 1);
 #endif
+    }
+}
+
+void check_ball_line_collisions(void) {
+    for (temp_byte_1 = 0; temp_byte_1 < get_ball_count(); ++temp_byte_1) {
+        temp_byte_2 = playfield[balls[temp_byte_1].nearest_playfield_tile];
     }
 }
 

--- a/jeznes.h
+++ b/jeznes.h
@@ -195,8 +195,17 @@ struct Ball balls[MAX_BALLS];
 #define set_line_orientation_flag(line_index, orientation) (lines[(line_index)].flags = lines[(line_index)].flags & ~LINE_BITMASK_ORIENTATION | (orientation))
 
 struct Line {
-    // Origin playfield tile index for the line
+    // Origin playfield tile index for the line.
+    // This is the tile on which the player pressed the start line button.
+    // For the game, the origin tile is always part of the line segment which
+    // spreads in the negative direction and the tile to the right
+    // (for ORIENTATION_HORIZ lines) or the tile below it (for ORIENTATION_VERT
+    // lines) is where the line segment which spreads in the positive direction
+    // begins.
     int origin;
+
+    // How many steps away from the origin playfield tiles have we taken?
+    unsigned char tile_step_count;
 
     // Current playfield tile index for line in both directions
     int current_neg;

--- a/jeznes.h
+++ b/jeznes.h
@@ -217,16 +217,73 @@ struct ObjectBase {
     unsigned char height;
 };
 
+enum {
+    LINE_DIRECTION_POSITIVE,
+    LINE_DIRECTION_NEGATIVE
+};
+
 #define PLAYFIELD_BIT_LINE_ORIENTATION 7
 #define PLAYFIELD_BITMASK_LINE_ORIENTATION (1 << PLAYFIELD_BIT_LINE_ORIENTATION)
 #define PLAYFIELD_BIT_LINE_INDEX 6
 #define PLAYFIELD_BITMASK_LINE_INDEX (1 << PLAYFIELD_BIT_LINE_INDEX)
-#define PLAYFIELD_BIT_MARK 5
+#define PLAYFIELD_BIT_LINE_DIRECTION 5
+#define PLAYFIELD_BITMASK_LINE_DIRECTION (1 << PLAYFIELD_BIT_LINE_DIRECTION)
+#define PLAYFIELD_BIT_MARK 4
 #define PLAYFIELD_BITMASK_MARK (1 << PLAYFIELD_BIT_MARK)
+
 // Bitmask for playfield byte which separates only the flag bits.
-#define PLAYFIELD_BITMASK_ALL (PLAYFIELD_BITMASK_LINE_ORIENTATION | PLAYFIELD_BITMASK_LINE_INDEX | PLAYFIELD_BITMASK_MARK)
+#define PLAYFIELD_BITMASK_ALL (PLAYFIELD_BITMASK_LINE_ORIENTATION | PLAYFIELD_BITMASK_LINE_INDEX | PLAYFIELD_BITMASK_LINE_DIRECTION | PLAYFIELD_BITMASK_MARK)
+
 // Bitmask for playfield byte which removes the flag bits.
 #define PLAYFIELD_BITMASK_NONE (~PLAYFIELD_BITMASK_ALL)
+
+#define get_playfield_flag(playfield_index, bitmask) get_flag(playfield[(playfield_index)], (bitmask))
+#define set_playfield_flag(playfield_index, bitmask) set_flag(playfield[(playfield_index)], (bitmask))
+#define unset_playfield_flag(playfield_index, bitmask) unset_flag(playfield[(playfield_index)], (bitmask))
+
+#define get_playfield_is_marked_flag(playfield_index) get_playfield_flag((playfield_index), PLAYFIELD_BITMASK_MARK)
+#define set_playfield_is_marked_flag(playfield_index) set_playfield_flag((playfield_index), PLAYFIELD_BITMASK_MARK)
+#define unset_playfield_is_marked_flag(playfield_index) unset_playfield_flag((playfield_index), PLAYFIELD_BITMASK_MARK)
+
+// Returns the line direction for a playfield byte which will be either LINE_DIRECTION_POSITIVE or LINE_DIRECTION_NEGATIVE
+#define get_playfield_line_direction_flag_from_byte(flags_byte) (((flags_byte) & PLAYFIELD_BITMASK_LINE_DIRECTION) >> PLAYFIELD_BIT_LINE_DIRECTION)
+
+// Returns the line direction for a playfield tile at |playfield_index| which will be either LINE_DIRECTION_POSITIVE or LINE_DIRECTION_NEGATIVE
+#define get_playfield_line_direction_flag(playfield_index) get_playfield_line_direction_flag_from_byte((playfield_index))
+
+// Returns the line orientation for a playfield byte which will be either ORIENTATION_HORIZ or ORIENTATION_VERT
+#define get_playfield_line_orientation_flag_from_byte(flags_byte) (((flags_byte) & PLAYFIELD_BITMASK_LINE_ORIENTATION) >> PLAYFIELD_BIT_LINE_ORIENTATION)
+
+// Returns the line orientation for a playfield tile at |playfield_index| which will be either ORIENTATION_HORIZ or ORIENTATION_VERT
+#define get_playfield_line_orientation_flag(playfield_index) (get_playfield_line_orientation_flag_from_byte(playfield[(playfield_index)]))
+
+// Sets the line orientation for |playfield_index| to |orientation| which must be either ORIENTATION_HORIZ or ORIENTATION_VERT
+#define set_playfield_line_orientation_flag(playfield_index, orientation) (playfield[(playfield_index)] = playfield[(playfield_index)] & ~PLAYFIELD_BITMASK_LINE_ORIENTATION | (orientation << PLAYFIELD_BIT_LINE_ORIENTATION))
+
+// Returns the line index from a playfield byte which will be either 0 or 1
+#define get_playfield_line_index_flag_from_byte(flags_byte) (((flags_byte) & PLAYFIELD_BITMASK_LINE_INDEX) >> PLAYFIELD_BIT_LINE_INDEX)
+
+// Returns the line index for a playfield tile at |playfield_index| which will be either 0 or 1
+#define get_playfield_line_index_flag(playfield_index) (get_playfield_line_index_flag_from_byte(playfield[(playfield_index)]))
+
+// Sets the line index for |playfield_index| to |index| which must be either 0 or 1
+#define set_playfield_line_index_flag(playfield_index, index) (playfield[(playfield_index)] = playfield[(playfield_index)] & ~PLAYFIELD_BITMASK_LINE_INDEX | (index << PLAYFIELD_BIT_LINE_INDEX))
+
+// Returns the playfield tile type from a playfield byte |flags_byte| by removing the bit-flags from the playfield byte
+#define get_playfield_tile_type_from_byte(flags_byte) ((flags_byte) & PLAYFIELD_BITMASK_NONE)
+
+// Returns the playfield tile type for |playfield_index| by removing the bit-flags from the playfield byte
+#define get_playfield_tile_type(playfield_index) get_playfield_tile_type_from_byte(playfield[(playfield_index)])
+
+// Get the playfield tile type for lines.
+// Indicate horizontal or vertical via |orientation| which should be ORIENTATION_HORIZ or ORIENTATION_VERT.
+// Indicate the line index via |line_index| which must be 0 or 1.
+// Indicate the line direction via |line_direction| which should be LINE_DIRECTION_POSITIVE or LINE_DIRECTION_NEGATIVE.
+#define get_playfield_tile_type_line(orientation, line_index, line_direction) (PLAYFIELD_LINE | ((orientation) << PLAYFIELD_BIT_LINE_ORIENTATION) | ((line_index) << PLAYFIELD_BIT_LINE_INDEX) | ((line_direction) << PLAYFIELD_BIT_LINE_DIRECTION))
+
+// Get the bg tile graphic index for lines.
+// Indicate horizontal or vertical via |orientation| which should be ORIENTATION_HORIZ or ORIENTATION_VERT.
+#define get_playfield_bg_tile_line(orientation) (TILE_INDEX_PLAYFIELD_LINE_HORIZ + (orientation))
 
 enum {
     PLAYFIELD_UNCLEARED,

--- a/jeznes.h
+++ b/jeznes.h
@@ -253,6 +253,7 @@ void __fastcall__ move_ball(unsigned char ball_index);
 
 void move_balls(void);
 void draw_balls(void);
+void check_ball_line_collisions(void);
 
 void __fastcall__ start_line(unsigned char player_index);
 void __fastcall__ flip_player_orientation(unsigned char player_index);

--- a/jeznes.h
+++ b/jeznes.h
@@ -99,6 +99,9 @@ int temp_int_2;
 int temp_int_3;
 int temp_int_4;
 
+// Just placeholder to track how many bytes are unused in the zeropage.
+unsigned char unused_zp_bytes[8];
+
 #define get_flag(flags_byte, bitmask) (((flags_byte) & (bitmask)) != 0)
 #define set_flag(flags_byte, bitmask) ((flags_byte) |= (bitmask))
 #define unset_flag(flags_byte, bitmask) ((flags_byte) &= ~(bitmask))


### PR DESCRIPTION
Implement ball-line tile collisions by checking the playfield flags when a ball enters a playfield tile of type PLAYFIELD_LINE.

A ball colliding with a line tile will complete the associated line segment without clearing the tiles comprising the line.

The player loses a life during one of these collisions, though there is no game over screen or anything like that.

Note: The current front tile of each line segment is drawn as a sprite and this pull request does not implement collision detection between that tile and the ball sprites.