### PR TITLE
Add level-up mechanism

### DIFF
--- a/jeznes.c
+++ b/jeznes.c
@@ -159,7 +159,7 @@ void init_game(void) {
     }
 
     // Always loads |current_level|
-    load_level();
+    reset_playfield();
 }
 
 void load_playfield(unsigned char playfield_index) {
@@ -173,7 +173,7 @@ void read_controllers(void) {
     }
 }
 
-void load_level() {
+void reset_playfield() {
     // Reset per-level state.
     cleared_tile_count = 0;
     cleared_tile_percentage = 0;
@@ -217,7 +217,7 @@ void do_level_up(void) {
     ppu_off();
 
     // Redraw the playfield and reset the balls while adding one more.
-    load_level();
+    reset_playfield();
 
     // Turn on the screen.
     ppu_on_all();

--- a/jeznes.h
+++ b/jeznes.h
@@ -329,7 +329,7 @@ void init_title(void);
 void start_game(void);
 
 void init_game(void);
-void load_level(void);
+void reset_playfield(void);
 void __fastcall__ load_playfield(unsigned char playfield_index);
 
 void do_level_up(void);

--- a/jeznes.h
+++ b/jeznes.h
@@ -6,6 +6,8 @@
 #define BALL_WIDTH 8
 #define BALL_HEIGHT 8
 
+#define TARGET_CLEARED_TILE_PERCENTAGE 75
+
 // Playfield tile offsets
 #define PLAYFIELD_FIRST_TILE_X 1
 #define PLAYFIELD_FIRST_TILE_Y 2
@@ -43,7 +45,7 @@
 
 // These macros enable various debugging features and should probably be turned off before release
 #define DEBUG 1
-#define DRAW_GRAY_LINE 0
+#define DRAW_GRAY_LINE 1
 #define DRAW_BALL_NEAREST_TILE_HIGHLIGHT 1
 
 #define make_word(lo,hi) ((lo)|(hi << 8))
@@ -71,7 +73,7 @@ enum {
 #pragma bss-name(push, "ZEROPAGE")
 
 // Placeholder to track how many bytes are unused in the zeropage.
-unsigned char unused_zp_bytes[14];
+unsigned char unused_zp_bytes[13];
 
 unsigned char pads[MAX_PLAYERS];
 unsigned char pads_new[MAX_PLAYERS];
@@ -79,6 +81,7 @@ unsigned char pads_new[MAX_PLAYERS];
 enum {
     GAME_STATE_TITLE,
     GAME_STATE_PLAYING,
+    GAME_STATE_LEVEL_UP,
     GAME_STATE_UPDATING_PLAYFIELD,
     GAME_STATE_REQUEST_HUD_UPDATE
 };
@@ -86,6 +89,7 @@ enum {
 unsigned char game_state;
 unsigned char current_level;
 unsigned char lives_count;
+unsigned char cleared_tile_percentage;
 unsigned int cleared_tile_count;
 
 unsigned char temp_byte_1;
@@ -324,6 +328,7 @@ void init_title(void);
 void start_game(void);
 
 void init_game(void);
+void __fastcall__ load_level(unsigned char level);
 void __fastcall__ load_playfield(unsigned char playfield_index);
 
 void read_controllers(void);

--- a/jeznes.h
+++ b/jeznes.h
@@ -50,7 +50,7 @@
 
 #define make_word(lo,hi) ((lo)|(hi << 8))
 
-#define get_ball_count() (current_level)
+#define get_ball_count() (current_level+1)
 #define get_player_count() (1)
 
 #define get_playfield_index() (temp_int_3)
@@ -82,6 +82,7 @@ enum {
     GAME_STATE_TITLE,
     GAME_STATE_PLAYING,
     GAME_STATE_LEVEL_UP,
+    GAME_STATE_GAME_OVER,
     GAME_STATE_UPDATING_PLAYFIELD,
     GAME_STATE_REQUEST_HUD_UPDATE
 };
@@ -328,8 +329,10 @@ void init_title(void);
 void start_game(void);
 
 void init_game(void);
-void __fastcall__ load_level(unsigned char level);
+void load_level(void);
 void __fastcall__ load_playfield(unsigned char playfield_index);
+
+void do_level_up(void);
 
 void read_controllers(void);
 


### PR DESCRIPTION
When recalculating the cleared tile percentage, if it is greater than the target (75%) trigger a level up.

Level up should display a summary score message and reset the playfield to include one more ball.

Note: This PR does not add the summary score message, just increases the number of balls and resets the playfield.