### PR TITLE
Fix Windows compile.bat script

### DIFF
--- a/compile.bat
+++ b/compile.bat
@@ -5,17 +5,8 @@ set name="jeznes"
 set CC65_HOME=..\cc65\bin\
 set path=%path%;%CC65_HOME%
 
-cc65 -Oirs src/%name%.c -g --add-source
-ca65 src/crt0.s -g
-ca65 src/%name%.s -g
+cc65 -Oirs src/%name%.c -o build/%name%.s -g --add-source
+ca65 src/crt0.s -o build/crt0.o -g
+ca65 build/%name%.s -o build/%name%.o -g
 
-ld65 -C nrom_32k_vert.cfg -o %name%.nes crt0.o %name%.o nes.lib -Ln labels.txt --dbgfile %name%.dbg
-
-move /Y labels.txt BUILD\ 1>NUL
-move /Y %name%.s BUILD\ 1>NUL
-move /Y %name%.nes BUILD\ 1>NUL
-move /Y %name%.dbg BUILD\ 1>NUL
-move /Y *.o BUILD\ 1>NUL
-
-rem pause
-rem BUILD\%name%.nes
+ld65 -C nrom_32k_vert.cfg -o build/%name%.nes build/crt0.o build/%name%.o nes.lib -Ln build/%name%.labels.txt --dbgfile build/%name%.dbg


### PR DESCRIPTION
The batch file used to build on Windows was broken by the source file reorganization. Just fixes it.