### PR TITLE
Disable clang-tidy as a build step

### DIFF
--- a/.clang-format-ignore
+++ b/.clang-format-ignore
@@ -1,0 +1,6 @@
+# Skip files in lib
+src/lib/*.*
+
+# Skip ASM files
+src/*.s
+src/**/*.s

--- a/.clang-format-include
+++ b/.clang-format-include
@@ -1,0 +1,2 @@
+# All files in src/ and its subdirectories
+src/**/*

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -10,8 +10,10 @@ Checks: 'bugprone*,
          llvm*,
          -*-avoid-c-arrays,
          -bugprone-easily-swappable-parameters,
+         -bugprone-implicit-widening-of-multiplication-result,
          -bugprone-narrowing-conversions,
          -bugprone-reserved-identifier,
+         -bugprone-suspicious-include,
          -cert-dcl37-c,
          -cert-dcl51-cpp,
          -cert-err58-cpp,
@@ -29,4 +31,4 @@ Checks: 'bugprone*,
          -readability-magic-numbers,
          -readability-simplify-boolean-expr'
 WarningsAsErrors: '*'
-HeaderFilterRegex: '.'
+HeaderFilterRegex: '.*'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,11 +2,6 @@ cmake_minimum_required(VERSION 3.16.3)
 
 set(CMAKE_TOOLCHAIN_FILE toolchain/cc65-toolchain.cmake)
 
-find_program (CLANG_TIDY_EXE NAMES "clang-tidy")
-if (CLANG_TIDY_EXE)
-  set (CMAKE_C_CLANG_TIDY clang-tidy)
-endif ()
-
 set (CMAKE_C_STANDARD 11)
 
 project(jeznes C ASM)

--- a/src/lib/nesdoug.h
+++ b/src/lib/nesdoug.h
@@ -8,7 +8,6 @@
 // you shouldn't have to turn the screen off...
 // allowing us to make smooth scrolling games.
 
-// NOLINTBEGIN
 
 void set_vram_buffer(void);
 // sets the vram update to point to the vram_buffer. VRAM_BUF defined in crt0.s
@@ -166,4 +165,3 @@ void gray_line(void);
 void seed_rng(void);
 // get from the frame count. You can use a button (start on title screen) to trigger
 
-// NOLINTEND

--- a/src/lib/neslib.h
+++ b/src/lib/neslib.h
@@ -15,8 +15,6 @@
 // previous versions were created since mid-2011, there were many updates
 
 
-// NOLINTBEGIN
-
 
 //set bg and spr palettes, data is 32 bytes array
 
@@ -317,4 +315,3 @@ void __fastcall__ delay(unsigned char frames);
 #define MSB(x)			(((x)>>8))
 #define LSB(x)			(((x)&0xff))
 
-// NOLINTEND


### PR DESCRIPTION
clang-tidy doesn't play well with some of the flags for cc65 and doesn't understand `__fastcall__` which neslib uses. 