### PR TITLE
Simplify playfield tile mark bit handling

### DIFF
--- a/src/constants/sprites.h
+++ b/src/constants/sprites.h
@@ -20,7 +20,8 @@
 
 #define SPRITE_INDEX_CURSOR 0x17
 
-// Sprites for the PAUSE! chars are laid-out sequentially starting at this sprite index.
+// Sprites for the PAUSE! chars are laid-out sequentially starting at this
+// sprite index.
 #define SPRITE_INDEX_PAUSE_BASE 0x23
 
 #endif  // __JEZNES_CONSTANTS_SPRITES_H__

--- a/src/flags/line.h
+++ b/src/flags/line.h
@@ -25,6 +25,13 @@
 #define unset_line_flag(line_index, bitmask) \
   unset_flag(lines[(line_index)].flags, (bitmask))
 
+#define get_line_is_started_flag_from_byte(flags_byte) \
+  get_flag((flags_byte), LINE_BITMASK_IS_STARTED)
+#define set_line_is_started_flag_in_byte(flags_byte) \
+  set_flag((flags_byte), LINE_BITMASK_IS_STARTED)
+#define unset_line_is_started_flag_in_byte(flags_byte) \
+  unset_flag((flags_byte), LINE_BITMASK_IS_STARTED)
+
 #define get_line_is_started_flag(line_index) \
   get_line_flag((line_index), LINE_BITMASK_IS_STARTED)
 #define set_line_is_started_flag(line_index) \
@@ -32,12 +39,26 @@
 #define unset_line_is_started_flag(line_index) \
   unset_line_flag((line_index), LINE_BITMASK_IS_STARTED)
 
+#define get_line_is_positive_complete_flag_from_byte(flags_byte) \
+  get_flag((flags_byte), LINE_BITMASK_IS_POS_COMPLETE)
+#define set_line_is_positive_complete_flag_in_byte(flags_byte) \
+  set_flag((flags_byte), LINE_BITMASK_IS_POS_COMPLETE)
+#define unset_line_is_positive_complete_flag_in_byte(flags_byte) \
+  unset_flag((flags_byte), LINE_BITMASK_IS_POS_COMPLETE)
+
 #define get_line_is_positive_complete_flag(line_index) \
   get_line_flag((line_index), LINE_BITMASK_IS_POS_COMPLETE)
 #define set_line_is_positive_complete_flag(line_index) \
   set_line_flag((line_index), LINE_BITMASK_IS_POS_COMPLETE)
 #define unset_line_is_positive_complete_flag(line_index) \
   unset_line_flag((line_index), LINE_BITMASK_IS_POS_COMPLETE)
+
+#define get_line_is_negative_complete_flag_from_byte(flags_byte) \
+  get_flag((flags_byte), LINE_BITMASK_IS_NEG_COMPLETE)
+#define set_line_is_negative_complete_flag_in_byte(flags_byte) \
+  set_flag((flags_byte), LINE_BITMASK_IS_NEG_COMPLETE)
+#define unset_line_is_negative_complete_flag_in_byte(flags_byte) \
+  unset_flag((flags_byte), LINE_BITMASK_IS_NEG_COMPLETE)
 
 #define get_line_is_negative_complete_flag(line_index) \
   get_line_flag((line_index), LINE_BITMASK_IS_NEG_COMPLETE)

--- a/src/flags/player.h
+++ b/src/flags/player.h
@@ -66,7 +66,7 @@
 
 // Returns either ORIENTATION_HORIZ or ORIENTATION_VERT
 #define get_player_orientation_flag_from_byte(flags_byte) \
-  ((flags_byte) & PLAYER_BITMASK_ORIENTATION)
+  ((flags_byte)&PLAYER_BITMASK_ORIENTATION)
 
 // Returns either ORIENTATION_HORIZ or ORIENTATION_VERT
 #define get_player_orientation_flag(player_index) \

--- a/src/flags/playfield.h
+++ b/src/flags/playfield.h
@@ -33,6 +33,9 @@
 #define unset_playfield_flag(playfield_index, bitmask) \
   unset_flag(playfield[(playfield_index)], (bitmask))
 
+#define get_playfield_is_marked_flag_from_byte(flags_byte) \
+  get_flag((flags_byte), PLAYFIELD_BITMASK_MARK)
+
 #define get_playfield_is_marked_flag(playfield_index) \
   get_playfield_flag((playfield_index), PLAYFIELD_BITMASK_MARK)
 #define set_playfield_is_marked_flag(playfield_index) \

--- a/src/jeznes.c
+++ b/src/jeznes.c
@@ -1151,10 +1151,12 @@ void check_ball_line_collisions(void) {
     return;
   }
 
+  // Run through all the balls and check to see which type of playfield tile they are located in.
   for (temp_byte_1 = 0; temp_byte_1 < get_ball_count(); ++temp_byte_1) {
     set_current_playfield_index(balls[temp_byte_1].nearest_playfield_tile);
     temp_byte_2 = playfield[get_current_playfield_index()];
 
+    // The ball collides with a line if the playfield tile under the ball is a line tile.
     if (get_playfield_tile_type_from_byte(temp_byte_2) != PLAYFIELD_LINE) {
       // No collision.
       continue;
@@ -1164,7 +1166,8 @@ void check_ball_line_collisions(void) {
         get_playfield_line_orientation_flag_from_byte(temp_byte_2));
     set_tile_index_delta(compute_tile_index_delta(get_line_orientation()));
     temp_byte_3 = get_playfield_line_index_flag_from_byte(temp_byte_2);
-    set_negative_line_segment_origin(lines[temp_byte_3].origin);
+    set_temp_ptr(&lines[temp_byte_3]);
+    set_negative_line_segment_origin(get_temp_ptr(struct Line)->origin);
 
     if (get_playfield_line_direction_flag_from_byte(temp_byte_2) ==
         LINE_DIRECTION_NEGATIVE) {
@@ -1173,7 +1176,7 @@ void check_ball_line_collisions(void) {
       // metadata to include the line flags for this tile so we don't need
       // to do anything to the playfield for this tile index.
       set_current_playfield_index(get_negative_line_segment_origin() -
-                                  lines[temp_byte_3].tile_step_count *
+                                  get_temp_ptr(struct Line)->tile_step_count *
                                       get_tile_index_delta());
 
       // Walk back across the line segment (to origin) and reset the playfield
@@ -1194,12 +1197,12 @@ void check_ball_line_collisions(void) {
 
       // Turn off the negative-direction line segment - the collision stopped
       // it.
-      set_line_is_negative_complete_flag(temp_byte_3);
+      set_line_is_negative_complete_flag_in_byte(get_temp_ptr(struct Line)->flags);
 
       // If the other direction is also complete, reset the is_started flag of
       // the line.
-      if (get_line_is_positive_complete_flag(temp_byte_3)) {
-        unset_line_is_started_flag(temp_byte_3);
+      if (get_line_is_positive_complete_flag_from_byte(get_temp_ptr(struct Line)->flags)) {
+        unset_line_is_started_flag_in_byte(get_temp_ptr(struct Line)->flags);
       }
     } else {
       set_positive_line_segment_origin(get_negative_line_segment_origin() +
@@ -1210,7 +1213,7 @@ void check_ball_line_collisions(void) {
       // metadata to include the line flags for this tile so we don't need
       // to do anything to the playfield for this tile index.
       set_current_playfield_index(get_positive_line_segment_origin() +
-                                  lines[temp_byte_3].tile_step_count *
+                                  get_temp_ptr(struct Line)->tile_step_count *
                                       get_tile_index_delta());
 
       // Walk back across the line segment (to origin) and reset the playfield
@@ -1231,12 +1234,12 @@ void check_ball_line_collisions(void) {
 
       // Turn off the positive-direction line segment - the collision stopped
       // it.
-      set_line_is_positive_complete_flag(temp_byte_3);
+      set_line_is_positive_complete_flag_in_byte(get_temp_ptr(struct Line)->flags);
 
       // If the other direction is also complete, reset the is_started flag of
       // the line.
-      if (get_line_is_negative_complete_flag(temp_byte_3)) {
-        unset_line_is_started_flag(temp_byte_3);
+      if (get_line_is_negative_complete_flag_from_byte(get_temp_ptr(struct Line)->flags)) {
+        unset_line_is_started_flag_in_byte(get_temp_ptr(struct Line)->flags);
       }
     }
 

--- a/src/jeznes.c
+++ b/src/jeznes.c
@@ -91,7 +91,8 @@ int main(void) {
           continue;
         }
 
-        // Stash a pointer to the player so we don't need to access it via the array everywhere.
+        // Stash a pointer to the player so we don't need to access it via the
+        // array everywhere.
         set_temp_ptr(&players[temp_byte_1]);
 
         // Move the player position in the playfield.
@@ -499,9 +500,11 @@ void change_to_level_up(void) {
 void update_hud_level_up(void) {
   write_two_digit_number_to_bg(current_level, LEVEL_UP_LEVEL_DISPLAY_TILE_X,
                                LEVEL_UP_LEVEL_DISPLAY_TILE_Y);
-  write_score_to_bg(get_lives_bonus(lives_count), LEVEL_UP_LIFE_BONUS_DISPLAY_TILE_X,
+  write_score_to_bg(get_lives_bonus(lives_count),
+                    LEVEL_UP_LIFE_BONUS_DISPLAY_TILE_X,
                     LEVEL_UP_LIFE_BONUS_DISPLAY_TILE_Y);
-  write_score_to_bg(get_cleared_bonus(cleared_tile_percentage), LEVEL_UP_CLEAR_BONUS_DISPLAY_TILE_X,
+  write_score_to_bg(get_cleared_bonus(cleared_tile_percentage),
+                    LEVEL_UP_CLEAR_BONUS_DISPLAY_TILE_X,
                     LEVEL_UP_CLEAR_BONUS_DISPLAY_TILE_Y);
   write_score_to_bg(score, LEVEL_UP_SCORE_DISPLAY_TILE_X,
                     LEVEL_UP_SCORE_DISPLAY_TILE_Y);
@@ -519,7 +522,8 @@ unsigned char press_start_level_up(void) {
 }
 
 void draw_cursor_level_up(void) {
-  oam_spr(LEVEL_UP_CURSOR_CONTINUE_X, LEVEL_UP_CURSOR_CONTINUE_Y, SPRITE_INDEX_CURSOR, 0);
+  oam_spr(LEVEL_UP_CURSOR_CONTINUE_X, LEVEL_UP_CURSOR_CONTINUE_Y,
+          SPRITE_INDEX_CURSOR, 0);
 }
 
 void game_over_update_hud(void) {
@@ -708,10 +712,12 @@ void move_player(unsigned char player_index) {
   // Move player left or right (both cannot be pressed at the same time).
   if (temp_byte_2 & PAD_RIGHT) {
     set_pixel_coord_x(get_temp_ptr(struct Player)->x + PLAYER_SPEED);
-    get_temp_ptr(struct Player)->x = MIN(get_pixel_coord_x(), PLAYFIELD_RIGHT_WALL);
+    get_temp_ptr(struct Player)->x =
+        MIN(get_pixel_coord_x(), PLAYFIELD_RIGHT_WALL);
   } else if (temp_byte_2 & PAD_LEFT) {
     set_pixel_coord_x(get_temp_ptr(struct Player)->x - PLAYER_SPEED);
-    if (get_player_orientation_flag_from_byte(get_temp_ptr(struct Player)->flags) == ORIENTATION_HORIZ) {
+    if (get_player_orientation_flag_from_byte(
+            get_temp_ptr(struct Player)->flags) == ORIENTATION_HORIZ) {
       temp_byte_3 = PLAYFIELD_LEFT_WALL + 8;
     } else {
       temp_byte_3 = PLAYFIELD_LEFT_WALL;
@@ -722,10 +728,12 @@ void move_player(unsigned char player_index) {
   // Now move the player up or down (both cannot be pressed at the same time).
   if (temp_byte_2 & PAD_DOWN) {
     set_pixel_coord_y(get_temp_ptr(struct Player)->y + PLAYER_SPEED);
-    get_temp_ptr(struct Player)->y = MIN(get_pixel_coord_y(), PLAYFIELD_BOTTOM_WALL);
+    get_temp_ptr(struct Player)->y =
+        MIN(get_pixel_coord_y(), PLAYFIELD_BOTTOM_WALL);
   } else if (temp_byte_2 & PAD_UP) {
     set_pixel_coord_y(get_temp_ptr(struct Player)->y - PLAYER_SPEED);
-    if (get_player_orientation_flag_from_byte(get_temp_ptr(struct Player)->flags) == ORIENTATION_HORIZ) {
+    if (get_player_orientation_flag_from_byte(
+            get_temp_ptr(struct Player)->flags) == ORIENTATION_HORIZ) {
       temp_byte_3 = PLAYFIELD_TOP_WALL;
     } else {
       temp_byte_3 = PLAYFIELD_TOP_WALL + 8;
@@ -739,10 +747,11 @@ void move_player(unsigned char player_index) {
 void move_and_draw_balls(void) {
   temp_byte_5 = get_frame_count();
 
-  // Determine which sprite frame we should use for the balls - they are all drawn with the same animation frame.
-  // get_frame_count() returns [0x0,0xff].
+  // Determine which sprite frame we should use for the balls - they are all
+  // drawn with the same animation frame. get_frame_count() returns [0x0,0xff].
   // SPRITE_FRAME_COUNT_BALL should be a factor of 256.
-  temp_byte_5 = ((temp_byte_5 >> 2) % SPRITE_FRAME_COUNT_BALL) + SPRITE_INDEX_BALL_BASE;
+  temp_byte_5 =
+      ((temp_byte_5 >> 2) % SPRITE_FRAME_COUNT_BALL) + SPRITE_INDEX_BALL_BASE;
 
   for (temp_byte_1 = 0; temp_byte_1 < get_ball_count(); ++temp_byte_1) {
     set_temp_ptr(&balls[temp_byte_1]);
@@ -834,7 +843,8 @@ void draw_player(void) {
   temp_byte_2 = temp_byte_2 >> 3 & 1;
 
   // Add 2 to get the vertical sprite.
-  if (get_player_orientation_flag_from_byte(get_temp_ptr(struct Player)->flags) != ORIENTATION_HORIZ) {
+  if (get_player_orientation_flag_from_byte(
+          get_temp_ptr(struct Player)->flags) != ORIENTATION_HORIZ) {
     temp_byte_2 += 2;
   }
 
@@ -846,8 +856,8 @@ void draw_tile_highlight(void) {
   if (playfield[get_temp_ptr(struct Player)->nearest_playfield_tile] ==
       PLAYFIELD_UNCLEARED) {
     oam_spr(get_temp_ptr(struct Player)->nearest_tile_x,
-            get_temp_ptr(struct Player)->nearest_tile_y - 1, SPRITE_INDEX_TILE_HIGHLIGHT,
-            1);
+            get_temp_ptr(struct Player)->nearest_tile_y - 1,
+            SPRITE_INDEX_TILE_HIGHLIGHT, 1);
   }
 }
 
@@ -1148,12 +1158,14 @@ void check_ball_line_collisions(void) {
     return;
   }
 
-  // Run through all the balls and check to see which type of playfield tile they are located in.
+  // Run through all the balls and check to see which type of playfield tile
+  // they are located in.
   for (temp_byte_1 = 0; temp_byte_1 < get_ball_count(); ++temp_byte_1) {
     set_current_playfield_index(balls[temp_byte_1].nearest_playfield_tile);
     temp_byte_2 = playfield[get_current_playfield_index()];
 
-    // The ball collides with a line if the playfield tile under the ball is a line tile.
+    // The ball collides with a line if the playfield tile under the ball is a
+    // line tile.
     if (get_playfield_tile_type_from_byte(temp_byte_2) != PLAYFIELD_LINE) {
       // No collision.
       continue;
@@ -1194,11 +1206,13 @@ void check_ball_line_collisions(void) {
 
       // Turn off the negative-direction line segment - the collision stopped
       // it.
-      set_line_is_negative_complete_flag_in_byte(get_temp_ptr(struct Line)->flags);
+      set_line_is_negative_complete_flag_in_byte(
+          get_temp_ptr(struct Line)->flags);
 
       // If the other direction is also complete, reset the is_started flag of
       // the line.
-      if (get_line_is_positive_complete_flag_from_byte(get_temp_ptr(struct Line)->flags)) {
+      if (get_line_is_positive_complete_flag_from_byte(
+              get_temp_ptr(struct Line)->flags)) {
         unset_line_is_started_flag_in_byte(get_temp_ptr(struct Line)->flags);
       }
     } else {
@@ -1231,11 +1245,13 @@ void check_ball_line_collisions(void) {
 
       // Turn off the positive-direction line segment - the collision stopped
       // it.
-      set_line_is_positive_complete_flag_in_byte(get_temp_ptr(struct Line)->flags);
+      set_line_is_positive_complete_flag_in_byte(
+          get_temp_ptr(struct Line)->flags);
 
       // If the other direction is also complete, reset the is_started flag of
       // the line.
-      if (get_line_is_negative_complete_flag_from_byte(get_temp_ptr(struct Line)->flags)) {
+      if (get_line_is_negative_complete_flag_from_byte(
+              get_temp_ptr(struct Line)->flags)) {
         unset_line_is_started_flag_in_byte(get_temp_ptr(struct Line)->flags);
       }
     }
@@ -1283,7 +1299,8 @@ void flip_player_orientation(unsigned char player_index) {
 
 // Don't modify temp_byte_1
 void update_nearest_tile(void) {
-  temp_byte_2 = get_player_orientation_flag_from_byte(get_temp_ptr(struct Player)->flags);
+  temp_byte_2 =
+      get_player_orientation_flag_from_byte(get_temp_ptr(struct Player)->flags);
 
   // Center of the player meta-sprite in pixel coords.
   if (temp_byte_2 == ORIENTATION_HORIZ) {
@@ -1296,7 +1313,8 @@ void update_nearest_tile(void) {
 
   get_temp_ptr(struct Player)->nearest_tile_x = (temp_byte_3 >> 3) << 3;
   get_temp_ptr(struct Player)->nearest_tile_y = (temp_byte_4 >> 3) << 3;
-  get_temp_ptr(struct Player)->nearest_playfield_tile = playfield_tile_from_pixel_coords(temp_byte_3, temp_byte_4);
+  get_temp_ptr(struct Player)->nearest_playfield_tile =
+      playfield_tile_from_pixel_coords(temp_byte_3, temp_byte_4);
 }
 
 void line_completed(void) {
@@ -1350,25 +1368,32 @@ unsigned char update_cleared_playfield_tiles(void) {
   temp_byte_3 = 0;
   // Look over all tiles in the playfield and for each uncleared, unmarked tile
   // change it to cleared.
-  for (; get_playfield_index() < PLAYFIELD_WIDTH * PLAYFIELD_HEIGHT; inc_playfield_index()) {
+  for (; get_playfield_index() < PLAYFIELD_WIDTH * PLAYFIELD_HEIGHT;
+       inc_playfield_index()) {
     temp_byte_4 = playfield[get_playfield_index()];
-    // Skip tiles which are not uncleared. These are walls or cleared tiles and we don't care if they're marked.
+    // Skip tiles which are not uncleared. These are walls or cleared tiles and
+    // we don't care if they're marked.
     // TODO(boingoing): What about PLAYFIELD_LINE tiles from the other player?
     if (get_playfield_tile_type_from_byte(temp_byte_4) != PLAYFIELD_UNCLEARED) {
       continue;
     }
 
-    // If the tile was marked, we aren't supposed to clear it. Mark implies there is a ball inside the same region.
+    // If the tile was marked, we aren't supposed to clear it. Mark implies
+    // there is a ball inside the same region.
     if (get_playfield_is_marked_flag_from_byte(temp_byte_4)) {
-      // While we're here... let's remove all the mark bits from uncleared tiles. We won't revisit this tile index during this sweep of the playfield.
+      // While we're here... let's remove all the mark bits from uncleared
+      // tiles. We won't revisit this tile index during this sweep of the
+      // playfield.
       unset_playfield_is_marked_flag(get_playfield_index());
       continue;
     }
 
-    // Unmarked, uncleared playfield tile. Let's reset it to cleared and track the count for this sweep as well as all-time for the level.
+    // Unmarked, uncleared playfield tile. Let's reset it to cleared and track
+    // the count for this sweep as well as all-time for the level.
     ++temp_byte_3;
     ++cleared_tile_count;
-    set_playfield_tile(get_playfield_index(), PLAYFIELD_WALL, TILE_INDEX_PLAYFIELD_CLEARED);
+    set_playfield_tile(get_playfield_index(), PLAYFIELD_WALL,
+                       TILE_INDEX_PLAYFIELD_CLEARED);
 
     // We can only queue about 40 tile updates per v-blank.
     if (temp_byte_3 >= MAX_TILE_UPDATES_PER_FRAME) {

--- a/src/jeznes.c
+++ b/src/jeznes.c
@@ -1351,7 +1351,6 @@ unsigned char update_cleared_playfield_tiles(void) {
   // Look over all tiles in the playfield and for each uncleared, unmarked tile
   // change it to cleared.
   for (; get_playfield_index() < PLAYFIELD_WIDTH * PLAYFIELD_HEIGHT; inc_playfield_index()) {
-
     temp_byte_4 = playfield[get_playfield_index()];
     // Skip tiles which are not uncleared. These are walls or cleared tiles and we don't care if they're marked.
     // TODO(boingoing): What about PLAYFIELD_LINE tiles from the other player?

--- a/src/jeznes.c
+++ b/src/jeznes.c
@@ -1350,8 +1350,7 @@ unsigned char update_cleared_playfield_tiles(void) {
   temp_byte_3 = 0;
   // Look over all tiles in the playfield and for each uncleared, unmarked tile
   // change it to cleared.
-  for (; get_playfield_index() < PLAYFIELD_WIDTH * PLAYFIELD_HEIGHT;
-       inc_playfield_index()) {
+  for (; get_playfield_index() < PLAYFIELD_WIDTH * PLAYFIELD_HEIGHT; inc_playfield_index()) {
 
     temp_byte_4 = playfield[get_playfield_index()];
     // Skip tiles which are not uncleared. These are walls or cleared tiles and we don't care if they're marked.
@@ -1367,10 +1366,10 @@ unsigned char update_cleared_playfield_tiles(void) {
       continue;
     }
 
-    temp_byte_3++;
-    cleared_tile_count++;
-    set_playfield_tile(get_playfield_index(), PLAYFIELD_WALL,
-                       TILE_INDEX_PLAYFIELD_CLEARED);
+    // Unmarked, uncleared playfield tile. Let's reset it to cleared and track the count for this sweep as well as all-time for the level.
+    ++temp_byte_3;
+    ++cleared_tile_count;
+    set_playfield_tile(get_playfield_index(), PLAYFIELD_WALL, TILE_INDEX_PLAYFIELD_CLEARED);
 
     // We can only queue about 40 tile updates per v-blank.
     if (temp_byte_3 >= MAX_TILE_UPDATES_PER_FRAME) {

--- a/src/jeznes.c
+++ b/src/jeznes.c
@@ -1349,13 +1349,20 @@ void set_playfield_tile(unsigned int tile_index,
 unsigned char update_cleared_playfield_tiles(void) {
   temp_byte_3 = 0;
   // Look over all tiles in the playfield and for each uncleared, unmarked tile
-  // change it to cleared
+  // change it to cleared.
   for (; get_playfield_index() < PLAYFIELD_WIDTH * PLAYFIELD_HEIGHT;
        inc_playfield_index()) {
 
-    // Skip tiles which are not uncleared (this includes marked tiles)
-    if (playfield[get_playfield_index()] != PLAYFIELD_UNCLEARED) {
-      // While we're here... let's remove all the mark bits, too.
+    temp_byte_4 = playfield[get_playfield_index()];
+    // Skip tiles which are not uncleared. These are walls or cleared tiles and we don't care if they're marked.
+    // TODO(boingoing): What about PLAYFIELD_LINE tiles from the other player?
+    if (get_playfield_tile_type_from_byte(temp_byte_4) != PLAYFIELD_UNCLEARED) {
+      continue;
+    }
+
+    // If the tile was marked, we aren't supposed to clear it. Mark implies there is a ball inside the same region.
+    if (get_playfield_is_marked_flag_from_byte(temp_byte_4)) {
+      // While we're here... let's remove all the mark bits from uncleared tiles. We won't revisit this tile index during this sweep of the playfield.
       unset_playfield_is_marked_flag(get_playfield_index());
       continue;
     }

--- a/src/jeznes.c
+++ b/src/jeznes.c
@@ -162,9 +162,6 @@ int main(void) {
       if (update_cleared_playfield_tiles() == TRUE) {
         // We might have cleared tiles, let's update the HUD.
         game_state = GAME_STATE_REQUEST_HUD_UPDATE;
-
-        // We finished updating the playfield tiles, let's remove the mark bits.
-        reset_playfield_mark_bit();
       }
     } else if (game_state == GAME_STATE_REQUEST_HUD_UPDATE) {
       // Update the level, lives remaining, percentages, etc.
@@ -1304,8 +1301,6 @@ void update_nearest_tile(void) {
 
 void line_completed(void) {
   unsigned char i;
-  reset_playfield_mark_bit();
-
   for (i = 0; i < get_ball_count(); ++i) {
     compute_playfield_mark_bit_one_ball(i);
   }
@@ -1357,8 +1352,11 @@ unsigned char update_cleared_playfield_tiles(void) {
   // change it to cleared
   for (; get_playfield_index() < PLAYFIELD_WIDTH * PLAYFIELD_HEIGHT;
        inc_playfield_index()) {
+
     // Skip tiles which are not uncleared (this includes marked tiles)
     if (playfield[get_playfield_index()] != PLAYFIELD_UNCLEARED) {
+      // While we're here... let's remove all the mark bits, too.
+      unset_playfield_is_marked_flag(get_playfield_index());
       continue;
     }
 
@@ -1376,15 +1374,4 @@ unsigned char update_cleared_playfield_tiles(void) {
 
   add_score_for_cleared_tiles(temp_byte_3);
   return TRUE;
-}
-
-// Reset the mark bit in all playfield tiles.
-//
-// scratch:
-// temp_int_1
-void reset_playfield_mark_bit(void) {
-  for (temp_int_1 = 0; temp_int_1 < PLAYFIELD_WIDTH * PLAYFIELD_HEIGHT;
-       ++temp_int_1) {
-    unset_playfield_is_marked_flag(temp_int_1);
-  }
 }

--- a/src/jeznes.h
+++ b/src/jeznes.h
@@ -99,7 +99,6 @@ void draw_line(unsigned char line_index);
 
 void update_hud(void);
 
-void reset_playfield_mark_bit(void);
 unsigned char update_cleared_playfield_tiles(void);
 void line_completed(void);
 

--- a/src/scoring.c
+++ b/src/scoring.c
@@ -16,9 +16,7 @@ void add_score_for_cleared_tiles(unsigned char tile_count) {
   score += tile_count * SCORE_PER_CLEARED_TILE;
 }
 
-void add_score_for_cleared_line(void) {
-  score += SCORE_PER_CLEARED_LINE;
-}
+void add_score_for_cleared_line(void) { score += SCORE_PER_CLEARED_LINE; }
 
 void add_score_for_level_up(void) {
   score += get_lives_bonus(lives_count);

--- a/src/screens/playfield.h
+++ b/src/screens/playfield.h
@@ -61,8 +61,9 @@
 // ORIENTATION_HORIZ or ORIENTATION_VERT.
 // Indicate if this is a positive line segment via |is_positive| which
 // must be TRUE/FALSE (0 or 1).
-#define get_playfield_bg_tile_line_origin(orientation, is_positive) \
-  (TILE_INDEX_PLAYFIELD_LINE_HORIZ_NEGATIVE_ORIGIN + (is_positive) + ((orientation) == ORIENTATION_HORIZ ? 0 : 2))
+#define get_playfield_bg_tile_line_origin(orientation, is_positive)  \
+  (TILE_INDEX_PLAYFIELD_LINE_HORIZ_NEGATIVE_ORIGIN + (is_positive) + \
+   ((orientation) == ORIENTATION_HORIZ ? 0 : 2))
 
 const char playfield_bg_palette[] = {0x0f, 0x30, 0x16, 0x28, 0x0f, 0x00,
                                      0x27, 0x31, 0x0f, 0x06, 0x16, 0x26,


### PR DESCRIPTION
Move the duty to unmark playfield tiles into `update_cleared_playfield_tiles()`. This removes `reset_playfield_mark_bit()` entirely which saves a lot of cycles when completing a line and when finishing a sweep over the playfield to clear unmarked, uncleared tiles.

It can still take a few frames for the sweep over the playfield to complete because we are only able to queue around 40 tile updates per v-blank.