### PR TITLE
Use pre-computed tables for the flood fill turn functions

### DIFF
--- a/src/flood_fill.h
+++ b/src/flood_fill.h
@@ -23,6 +23,27 @@ enum {
   MOVE_DIRECTION_DEFAULT = MOVE_DIRECTION_RIGHT
 };
 
+unsigned char reverse_direction_table[] = {
+  MOVE_DIRECTION_LEFT,
+  MOVE_DIRECTION_UP,
+  MOVE_DIRECTION_RIGHT,
+  MOVE_DIRECTION_DOWN,
+};
+
+unsigned char turn_right_table[] = {
+  MOVE_DIRECTION_DOWN,
+  MOVE_DIRECTION_LEFT,
+  MOVE_DIRECTION_UP,
+  MOVE_DIRECTION_RIGHT,
+};
+
+unsigned char turn_left_table[] = {
+  MOVE_DIRECTION_UP,
+  MOVE_DIRECTION_RIGHT,
+  MOVE_DIRECTION_DOWN,
+  MOVE_DIRECTION_LEFT,
+};
+
 #define get_current_position() (temp_int_1)
 #define set_current_position(a) (temp_int_1 = (a))
 #define get_mark() (temp_int_2)
@@ -51,9 +72,9 @@ enum {
 #define get_adjacent_marked_tile_count() (temp_byte_6)
 #define inc_adjacent_marked_tile_count() (++temp_byte_6)
 
-#define reverse_direction() (set_cur_dir((get_cur_dir() + 2) % 4))
-#define turn_right() (set_cur_dir((get_cur_dir() + 1) % 4))
-#define turn_left() (set_cur_dir((get_cur_dir() + 3) % 4))
+#define reverse_direction() (set_cur_dir(reverse_direction_table[get_cur_dir()]))
+#define turn_right() (set_cur_dir(turn_right_table[get_cur_dir()]))
+#define turn_left() (set_cur_dir(turn_left_table[get_cur_dir()]))
 #define move_forward() (set_current_position(get_front()))
 
 // Uses a constant-memory usage implementation of the painters algorithm to


### PR DESCRIPTION
This saves about 700,000 cycles in `compute_playfield_mark_bit_one_ball()` due to avoiding modulo operator.